### PR TITLE
Add Redis event streaming and async task processing

### DIFF
--- a/backend/app/services/event_bus.py
+++ b/backend/app/services/event_bus.py
@@ -1,0 +1,31 @@
+import os
+import json
+import asyncio
+from typing import Any, Dict, AsyncGenerator
+import redis.asyncio as redis
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+class EventProducer:
+    def __init__(self):
+        self.redis = redis.from_url(REDIS_URL, decode_responses=True)
+
+    async def produce(self, stream: str, data: Dict[str, Any]) -> str:
+        """Add event to Redis stream and return event id"""
+        event_id = await self.redis.xadd(stream, {"data": json.dumps(data)})
+        return event_id
+
+class EventConsumer:
+    def __init__(self):
+        self.redis = redis.from_url(REDIS_URL, decode_responses=True)
+
+    async def consume(self, stream: str, last_id: str = "0-0") -> AsyncGenerator[Dict[str, Any], None]:
+        """Yield events from a Redis stream starting after last_id"""
+        while True:
+            events = await self.redis.xread({stream: last_id}, block=0, count=1)
+            for _, messages in events:
+                for message_id, message_data in messages:
+                    last_id = message_id
+                    payload = json.loads(message_data["data"])
+                    yield {"id": message_id, "data": payload}
+            await asyncio.sleep(0)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ pydantic==2.5.3
 python-multipart==0.0.6
 python-jose[cryptography]==3.3.0
 httpx==0.26.0
+redis==5.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,15 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ENVIRONMENT=development
       - FRONTEND_URL=http://localhost:8000
+      - REDIS_URL=redis://redis:6379/0
     volumes:
       - ./backend:/app
       - ./frontend:/frontend
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- add Redis service to docker-compose and dependency
- implement Redis-based EventProducer/EventConsumer
- publish OpenAI responses as events and process chat messages via FastAPI BackgroundTasks

## Testing
- `python -m py_compile backend/app/services/event_bus.py backend/app/services/openai_service.py backend/app/routes/chat.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c47647a60c8327abbea9292cb20bb8