### PR TITLE
feat: add agent routing

### DIFF
--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+
+
+class Agent(ABC):
+    """Base interface for conversational agents."""
+
+    @abstractmethod
+    def create_session(self) -> str:
+        """Create a new session identifier."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def handle_message(self, message: str, session_id: str) -> str:
+        """Process a message within a session and return a response."""
+        raise NotImplementedError

--- a/backend/app/services/agent_manager.py
+++ b/backend/app/services/agent_manager.py
@@ -1,0 +1,35 @@
+from typing import Dict, Optional, AsyncGenerator
+
+from .agent import Agent
+
+
+class AgentManager:
+    """Registry and router for different conversational agents."""
+
+    def __init__(self):
+        self._agents: Dict[str, Agent] = {}
+        self._default: Optional[str] = None
+
+    def register(self, name: str, agent: Agent, *, default: bool = False) -> None:
+        """Register a new agent under the given name."""
+        self._agents[name] = agent
+        if default or self._default is None:
+            self._default = name
+
+    def get(self, name: Optional[str] = None) -> Agent:
+        """Retrieve an agent by name or return the default agent."""
+        key = name or self._default
+        if key is None or key not in self._agents:
+            raise ValueError(f"Agent '{name}' not found")
+        return self._agents[key]
+
+    async def handle_message(self, name: Optional[str], message: str, session_id: str) -> str:
+        agent = self.get(name)
+        return await agent.handle_message(message, session_id)
+
+    async def handle_stream(self, name: Optional[str], message: str, session_id: str) -> AsyncGenerator[str, None]:
+        agent = self.get(name)
+        if not hasattr(agent, "get_stream_response"):
+            raise ValueError(f"Agent '{name}' does not support streaming responses")
+        async for chunk in agent.get_stream_response(message=message, session_id=session_id):
+            yield chunk

--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -7,6 +7,7 @@ class ChatApp {
         this.charCount = document.getElementById('charCount');
         this.statusElement = document.querySelector('.status-text');
         this.statusDot = document.querySelector('.status-dot');
+        this.agentSelect = document.getElementById('agentSelect');
         
         this.initEventListeners();
         this.checkHealth();
@@ -71,6 +72,8 @@ class ChatApp {
         
         try {
             // Send message to API
+            const agent = this.agentSelect ? this.agentSelect.value : null;
+
             const response = await fetch('/api/chat/stream', {
                 method: 'POST',
                 headers: {
@@ -78,7 +81,8 @@ class ChatApp {
                 },
                 body: JSON.stringify({
                     message: message,
-                    session_id: this.sessionId
+                    session_id: this.sessionId,
+                    agent: agent
                 })
             });
             


### PR DESCRIPTION
## Summary
- introduce `Agent` abstraction and `AgentManager` for routing
- expose agent selection through chat endpoints and frontend
- update OpenAI service to implement `Agent`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4764666f08327847eab1405c46ebc