### PR TITLE
Split docker compose configs for dev and prod

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyd
+
+# Node modules
+node_modules/
+frontend/node_modules/
+
+# Environment files
+.env
+.env.*
+
+# VCS and Compose files
+.git
+.gitignore
+docker-compose*.yml
+
+# Virtual environments
+venv/
+ENV/
+env/

--- a/README.md
+++ b/README.md
@@ -14,9 +14,44 @@ Ein production-ready AI Chatbot mit OpenAI Integration, optimiert für Dokploy D
 
 ## Quick Start
 
-### Lokale Entwicklung
+### Entwicklung
 
 1. Repository klonen:
+
 ```bash
 git clone <your-repo>
 cd ai-chatbot
+```
+
+2. OpenAI API Key setzen:
+
+```bash
+export OPENAI_API_KEY=dein_schluessel
+```
+
+3. Container mit Hot-Reload starten:
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+### Produktion
+
+1. Container im Hintergrund bauen und starten:
+
+```bash
+docker compose -f docker-compose.prod.yml up --build -d
+```
+
+2. Die Anwendung ist unter http://localhost:8000 erreichbar.
+
+## Manuelles Build
+
+Das Image kann auch ohne Compose gebaut werden:
+
+```bash
+docker build -t ai-chatbot .
+docker run -p 8000:8000 -e OPENAI_API_KEY=dein_schluessel ai-chatbot
+```
+
+Die Datei `.dockerignore` sorgt dafür, dass unnötige Dateien nicht in den Build-Kontext gelangen.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   chatbot:
-    build: ./backend
+    build: .
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  chatbot:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ENVIRONMENT=production
+      - FRONTEND_URL=http://localhost:8000


### PR DESCRIPTION
## Summary
- add `.dockerignore` to keep image lean
- create `docker-compose.dev.yml` and `docker-compose.prod.yml` with root build context
- document development and production build workflows in README

## Testing
- `pytest`
- `docker compose -f docker-compose.dev.yml config` *(fails: command not found)*
- `docker compose -f docker-compose.prod.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4764a14ac83279177baa700c696dc