### PR TITLE
Fix: Audit-Erstellung + KI-Chat als eigenständige Seite

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import ReportingPhase from './pages/ReportingPhase';
 import ActionTrackingPhase from './pages/ActionTrackingPhase';
 import DocumentsPage from './pages/DocumentsPage';
 import DashboardPage from './pages/DashboardPage';
+import ChatPage from './pages/ChatPage';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
         <Route element={<AppLayout />}>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/chat" element={<ChatPage />} />
           <Route path="/audits" element={<AuditListPage />} />
           <Route path="/audits/:id" element={<AuditDetailPage />}>
             <Route index element={<Navigate to="planung" replace />} />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,10 @@
 import { NavLink } from 'react-router-dom';
-import { FileText, LayoutDashboard } from 'lucide-react';
+import { FileText, LayoutDashboard, MessageSquare } from 'lucide-react';
 
 const navItems = [
     { to: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
     { to: '/audits', icon: FileText, label: 'Prüfungen' },
+    { to: '/chat', icon: MessageSquare, label: 'KI-Assistent' },
 ];
 
 const Sidebar: React.FC = () => {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useAudits } from '../context/AuditContext';
+import Chat from '../components/Chat';
+
+const ChatPage: React.FC = () => {
+    const { audits } = useAudits();
+    const [selectedAuditId, setSelectedAuditId] = useState<number | undefined>(undefined);
+
+    const selectedAudit = audits.find(a => a.id === selectedAuditId);
+
+    return (
+        <div className="flex h-full">
+            {/* Sidebar: Audit-Auswahl */}
+            <div className="w-64 bg-gray-50 border-r border-gray-200 flex flex-col">
+                <div className="p-4 border-b border-gray-200">
+                    <h3 className="text-sm font-semibold text-gray-600">Prüfungskontext</h3>
+                    <p className="text-xs text-gray-400 mt-1">
+                        Wählen Sie eine Prüfung für kontextbezogene Antworten
+                    </p>
+                </div>
+                <div className="flex-1 overflow-y-auto p-2 space-y-1">
+                    <button
+                        onClick={() => setSelectedAuditId(undefined)}
+                        className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                            !selectedAuditId
+                                ? 'bg-blue-100 text-blue-800'
+                                : 'text-gray-600 hover:bg-gray-100'
+                        }`}
+                    >
+                        Allgemein (kein Kontext)
+                    </button>
+                    {audits.map((audit) => (
+                        <button
+                            key={audit.id}
+                            onClick={() => setSelectedAuditId(audit.id)}
+                            className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                                selectedAuditId === audit.id
+                                    ? 'bg-blue-100 text-blue-800'
+                                    : 'text-gray-600 hover:bg-gray-100'
+                            }`}
+                        >
+                            <div className="font-medium truncate">{audit.title}</div>
+                            <div className="text-xs text-gray-400 mt-0.5">{audit.status}</div>
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* Chat */}
+            <div className="flex-1 flex flex-col">
+                <Chat
+                    key={selectedAuditId ?? 'general'}
+                    auditId={selectedAuditId}
+                    auditTitle={selectedAudit?.title}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default ChatPage;

--- a/services/ai-service/app/api/routes/audits.py
+++ b/services/ai-service/app/api/routes/audits.py
@@ -1,5 +1,5 @@
 from typing import List
-from datetime import date
+from datetime import date, datetime
 from enum import Enum
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -54,8 +54,8 @@ class AuditRead(BaseModel):
     start_date: date | None = None
     end_date: date | None = None
     responsible_person: str | None = None
-    created_at: str
-    updated_at: str | None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
     class Config:
         from_attributes = True

--- a/services/ai-service/app/api/routes/findings.py
+++ b/services/ai-service/app/api/routes/findings.py
@@ -1,5 +1,5 @@
 from typing import List
-from datetime import date
+from datetime import date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -38,8 +38,8 @@ class FindingRead(BaseModel):
     action_description: str | None
     action_due_date: date | None
     action_status: str | None
-    created_at: str | None
-    updated_at: str | None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
 
     class Config:
         from_attributes = True

--- a/services/ai-service/app/api/routes/risks.py
+++ b/services/ai-service/app/api/routes/risks.py
@@ -1,4 +1,5 @@
 from typing import List
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -28,7 +29,7 @@ class RiskRead(BaseModel):
     description: str | None
     impact: str | None
     likelihood: str | None
-    created_at: str | None
+    created_at: datetime | None = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
Bug-Fix:
- Pydantic Response-Modelle: created_at/updated_at von `str` auf `datetime` umgestellt — PostgreSQL gibt datetime-Objekte zurück, was mit `str`-Typ zu 500 Internal Server Error bei jedem API- Aufruf führte (audits, findings, risks betroffen)

Neue Features:
- KI-Assistent als eigenständige Seite (/chat) mit Sidebar-Link
- ChatPage: Prüfungskontext-Auswahl links, Chat rechts
- Chat weiterhin auch als Sidebar im Audit-Detail verfügbar

https://claude.ai/code/session_01W9WF2fADYJD8MZMK17WdvY